### PR TITLE
Remove fireweapon logic from the player/entity

### DIFF
--- a/Assets/Prefabs/Player/MainPlayer.prefab
+++ b/Assets/Prefabs/Player/MainPlayer.prefab
@@ -83,8 +83,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Health: 6
   MaxHealth: 6
-  weapon: {fileID: 0}
-  Speed: 0
   model: {fileID: 1224860693315704524}
   invincibilityDurationSeconds: 2
   delayBetweenInvincibilityFlashes: 0.2
@@ -125,8 +123,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f478840d7142f74c8b409e915224cf1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  weapon: {fileID: 8985372404558189384}
   projectileTag: PlayerProjectile
+  weaponInstance: {fileID: 8985372404558189384}
 --- !u!136 &2731797612632256719
 CapsuleCollider:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/SandboxScenes/JazySandbox.unity
+++ b/Assets/Scenes/SandboxScenes/JazySandbox.unity
@@ -1885,7 +1885,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 5.5999756, y: -4}
+  m_AnchoredPosition: {x: 5.625, y: -4}
   m_SizeDelta: {x: 185.96997, y: 60.700012}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &558802816
@@ -4182,11 +4182,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8985372404558189387, guid: 224198badb8d31847a3ab6b59ec2d3ff,
-        type: 3}
-      propertyPath: projectileInheritMomentum
-      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 224198badb8d31847a3ab6b59ec2d3ff, type: 3}

--- a/Assets/Scripts/Entity/Enemy/Enemy.cs
+++ b/Assets/Scripts/Entity/Enemy/Enemy.cs
@@ -13,7 +13,6 @@ public class Enemy : Entity
      */
     void Awake()
     {
-        SetWeapon(weapon);
     }
 
 

--- a/Assets/Scripts/Entity/Entity.cs
+++ b/Assets/Scripts/Entity/Entity.cs
@@ -10,31 +10,12 @@ public abstract class Entity : MonoBehaviour
     // The maximum health this entity can currently have
     public int MaxHealth;
 
-    // TODO Remove FireWeapon logic as this will now live in ShootController.cs
-    // The weapon this entity uses for attacking
-    public GameObject weapon;
-
-    // Reference to the script of the weapon
-    protected Weapon attackingWeapon;
-
     // The model that's expected to be a child of this game object
     public GameObject model;
     public void SetModel(GameObject model) { this.model = model; }
 
-
-    /* Sets this entity's weapon to the given GameObject.
-       TODO Remove FireWeapon logic as this will now live in ShootController.cs
-     */
-    public void SetWeapon(GameObject weapon)
-    {
-        this.weapon = weapon;
-        attackingWeapon = weapon.GetComponent<Weapon>();
-    }
-
-
     // Changes this entity's maximum health by the given amount
     public abstract void ChangeMaxHealthBy(int amount);
-
 
     // Changes this entity's current health by the given amount
     public abstract void ChangeHealthBy(int amount);

--- a/Assets/Scripts/Entity/Player/IWeaponController.cs
+++ b/Assets/Scripts/Entity/Player/IWeaponController.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public interface IWeaponController
+{
+    void SetWeaponInstance(GameObject wi);
+    GameObject GetWeaponInstance();
+
+}

--- a/Assets/Scripts/Entity/Player/IWeaponController.cs.meta
+++ b/Assets/Scripts/Entity/Player/IWeaponController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4cfa09ab0ce48f84ca1ffabea59eeb70
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Entity/Player/Player.cs
+++ b/Assets/Scripts/Entity/Player/Player.cs
@@ -4,7 +4,6 @@ using UnityEngine;
 
 public class Player : Entity
 {
-    // TODO Remove FireWeapon logic as this will now live in ShootController.cs
     // Used to signal health change events to the heart container system
     public delegate void HealthChanged();
     public event HealthChanged healthChangedEvent;
@@ -25,7 +24,6 @@ public class Player : Entity
     void Awake()
     {
         SetEnabled(true);
-        //SetWeapon(weapon);
         healthChangedEvent?.Invoke();
     }
 
@@ -59,18 +57,6 @@ public class Player : Entity
         }
     }
 
-
-    /* Allows this Player to fire its weapon, assuming it has one.
-     */ 
-    public void FireWeapon()
-    {
-        if (attackingWeapon != null)
-        {
-            attackingWeapon.Attack("PlayerProjectile");
-        }
-    }
-
-    
     /* Called when this Player encounters another object.
      */
     private void OnCollisionEnter(Collision other)
@@ -84,7 +70,7 @@ public class Player : Entity
             Projectile projectile = other.gameObject.GetComponent<Projectile>();
             ChangeHealthBy(projectile.damage);
             Destroy(other.gameObject);
-        }       
+        }
     }
 
 

--- a/Assets/Scripts/Entity/Player/ShootController.cs
+++ b/Assets/Scripts/Entity/Player/ShootController.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 public class ShootController : MonoBehaviour, IWeaponController
 {
     [SerializeField]
-    private string projectileTag;
+    private string projectileTag = "Untagged";
     [SerializeField]
     private GameObject weaponInstance;
 

--- a/Assets/Scripts/Entity/Player/ShootController.cs
+++ b/Assets/Scripts/Entity/Player/ShootController.cs
@@ -2,18 +2,24 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-public class ShootController : MonoBehaviour
+public class ShootController : MonoBehaviour, IWeaponController
 {
-    public GameObject weapon;
-    public string projectileTag;
-    private IWeapon fireableWeapon;
+    [SerializeField]
+    private string projectileTag;
+    [SerializeField]
+    private GameObject weaponInstance;
+
+    private Weapon weapon;
 
 
     /* Used to set up this script.
      */
     void Awake()
     {
-        SetWeapon(weapon);
+        if (!weaponInstance.activeSelf)
+            Debug.LogError("ShootController has non-active weapon reference!!");
+
+        SetWeaponInstance(weaponInstance);
     }
 
     /**
@@ -21,10 +27,15 @@ public class ShootController : MonoBehaviour
         The controller will handle firing the weapon through the exposed fire
         methods.
      */
-    public void SetWeapon(GameObject w)
+    public void SetWeaponInstance(GameObject w)
     {
-        weapon = w;
-        fireableWeapon = weapon.GetComponentInChildren<IWeapon>();
+        weaponInstance = w;
+        // Maybe this should look for ProjectileWeapon?
+        weapon = weapon.GetComponentInChildren<Weapon>();
+    }
+    public GameObject GetWeaponInstance()
+    {
+        return weaponInstance;
     }
 
     /**
@@ -40,7 +51,7 @@ public class ShootController : MonoBehaviour
 
     public void FireWeapon()
     {
-        if (fireableWeapon == null) return;
-        fireableWeapon.Fire(projectileTag);
+        if (weapon == null) return;
+        weapon.Attack(projectileTag);
     }
 }

--- a/Assets/Scripts/Entity/Player/ShootController.cs
+++ b/Assets/Scripts/Entity/Player/ShootController.cs
@@ -16,7 +16,7 @@ public class ShootController : MonoBehaviour, IWeaponController
      */
     void Awake()
     {
-        if (!weaponInstance.activeSelf)
+        if (weaponInstance.scene.name == null)
             Debug.LogError("ShootController has non-active weapon reference!!");
 
         SetWeaponInstance(weaponInstance);
@@ -31,7 +31,7 @@ public class ShootController : MonoBehaviour, IWeaponController
     {
         weaponInstance = w;
         // Maybe this should look for ProjectileWeapon?
-        weapon = weapon.GetComponentInChildren<Weapon>();
+        weapon = weaponInstance.GetComponentInChildren<Weapon>();
     }
     public GameObject GetWeaponInstance()
     {


### PR DESCRIPTION
The shootcontroller should handle all shoot/attacking
logic. The IAttackController interface will ensure that
a reference to the weapon object can be retrieved
(Mostly to be used by possession).

@klein1992 Make sure you understand the changes here and the changes that will need to happen to your current possession script. Please let me know if you have any questions.