### PR TITLE
Toned down meteors and various other arson fixes

### DIFF
--- a/Assets/Prefabs/Enemy/Devil/Devil.prefab
+++ b/Assets/Prefabs/Enemy/Devil/Devil.prefab
@@ -1952,7 +1952,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   rangedDistance: 18
   rangedWeapon: {fileID: 4383480593671820873}
-  meleeDistance: 5
+  meleeDistance: 4
   meleeWeapon: {fileID: 5543977890848250396}
   phaseTwoAudio: {fileID: 5794415566753781701}
 --- !u!114 &848345790902503960
@@ -2418,11 +2418,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 3623955585191402957}
     m_Modifications:
-    - target: {fileID: 7150264405949130727, guid: 530536aed588fe44385234ec6e1c483a,
-        type: 3}
-      propertyPath: m_Name
-      value: FireboltLauncher
-      objectReference: {fileID: 0}
     - target: {fileID: 7150264405949130725, guid: 530536aed588fe44385234ec6e1c483a,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -2477,6 +2472,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7150264405949130727, guid: 530536aed588fe44385234ec6e1c483a,
+        type: 3}
+      propertyPath: m_Name
+      value: FireboltLauncher
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 530536aed588fe44385234ec6e1c483a, type: 3}

--- a/Assets/Prefabs/Player/MainPlayer.prefab
+++ b/Assets/Prefabs/Player/MainPlayer.prefab
@@ -86,7 +86,7 @@ MonoBehaviour:
   MaxHealth: 6
   model: {fileID: 1224860693315704524}
   invincibilityDurationSeconds: 2
-  delayBetweenInvincibilityFlashes: 0.2
+  delayBetweenInvincibilityFlashes: 0.15
 --- !u!114 &3672507080587500165
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Weapons/Projectiles/Firebolt.prefab
+++ b/Assets/Prefabs/Weapons/Projectiles/Firebolt.prefab
@@ -5322,7 +5322,7 @@ ParticleSystem:
     startLifetime:
       serializedVersion: 2
       minMaxState: 0
-      scalar: 0.75
+      scalar: 0.4
       minScalar: 5
       maxCurve:
         serializedVersion: 2
@@ -5473,7 +5473,7 @@ ParticleSystem:
     startSize:
       serializedVersion: 2
       minMaxState: 3
-      scalar: 5
+      scalar: 4
       minScalar: 2
       maxCurve:
         serializedVersion: 2
@@ -5507,7 +5507,7 @@ ParticleSystem:
         m_RotationOrder: 4
     startSizeY:
       serializedVersion: 2
-      minMaxState: 0
+      minMaxState: 3
       scalar: 1
       minScalar: 1
       maxCurve:
@@ -5560,7 +5560,7 @@ ParticleSystem:
         m_RotationOrder: 4
     startSizeZ:
       serializedVersion: 2
-      minMaxState: 0
+      minMaxState: 3
       scalar: 1
       minScalar: 1
       maxCurve:
@@ -5613,7 +5613,7 @@ ParticleSystem:
         m_RotationOrder: 4
     startRotationX:
       serializedVersion: 2
-      minMaxState: 0
+      minMaxState: 3
       scalar: 0
       minScalar: 0
       maxCurve:
@@ -5666,7 +5666,7 @@ ParticleSystem:
         m_RotationOrder: 4
     startRotationY:
       serializedVersion: 2
-      minMaxState: 0
+      minMaxState: 3
       scalar: 0
       minScalar: 0
       maxCurve:
@@ -5899,7 +5899,7 @@ ParticleSystem:
     sphericalDirectionAmount: 0
     randomPositionAmount: 0
     radius:
-      value: 2
+      value: 1
       mode: 0
       spread: 0
       speed:

--- a/Assets/PyroParticles/Prefab/Prefab/Meteor.prefab
+++ b/Assets/PyroParticles/Prefab/Prefab/Meteor.prefab
@@ -92,7 +92,7 @@ Rigidbody:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 164416}
   serializedVersion: 2
-  m_Mass: 500
+  m_Mass: 1
   m_Drag: 0.1
   m_AngularDrag: 0.5
   m_UseGravity: 0

--- a/Assets/PyroParticles/Prefab/Prefab/Meteor.prefab
+++ b/Assets/PyroParticles/Prefab/Prefab/Meteor.prefab
@@ -363,7 +363,7 @@ SphereCollider:
   m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
-  m_Radius: 1
+  m_Radius: 1.5
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!114 &1700876310376838802
 MonoBehaviour:

--- a/Assets/PyroParticles/Prefab/Prefab/MeteorSwarm.prefab
+++ b/Assets/PyroParticles/Prefab/Prefab/MeteorSwarm.prefab
@@ -4719,13 +4719,13 @@ MonoBehaviour:
   - {fileID: 4300002, guid: 371ed6c0dd75f6a4ebd1dfcb0b578b46, type: 3}
   - {fileID: 4300000, guid: 371ed6c0dd75f6a4ebd1dfcb0b578b46, type: 3}
   - {fileID: 4300010, guid: 371ed6c0dd75f6a4ebd1dfcb0b578b46, type: 3}
-  DestinationRadius: 25
-  Source: {x: 50, y: 100, z: -50}
+  DestinationRadius: 5
+  SpawnHeight: 100
   SourceRadius: 10
   TimeToImpact: 1
   MeteorsPerSecondRange:
-    Minimum: 10
-    Maximum: 20
+    Minimum: 4
+    Maximum: 8
   ScaleRange:
     Minimum: 0.25
     Maximum: 1

--- a/Assets/PyroParticles/Prefab/Prefab/SmallFires.prefab
+++ b/Assets/PyroParticles/Prefab/Prefab/SmallFires.prefab
@@ -14407,5 +14407,5 @@ BoxCollider:
   m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 1.2, y: 0.2, z: 1.2}
+  m_Size: {x: 1.5, y: 0.2, z: 1.5}
   m_Center: {x: 0, y: 1.5, z: 0}

--- a/Assets/PyroParticles/Prefab/Prefab/WallOfFire.prefab
+++ b/Assets/PyroParticles/Prefab/Prefab/WallOfFire.prefab
@@ -4772,6 +4772,8 @@ GameObject:
   - component: {fileID: 494314}
   - component: {fileID: 11496392}
   - component: {fileID: 11456478}
+  - component: {fileID: 4320766977030961742}
+  - component: {fileID: 430065807486455890}
   m_Layer: 8
   m_Name: WallOfFire
   m_TagString: Untagged
@@ -4836,6 +4838,31 @@ MonoBehaviour:
   ForceRadius: 0
   IsProjectile: 0
   ManualParticleSystems: []
+--- !u!114 &4320766977030961742
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 118616}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 05fdd08137dbfe841b1b9fcf33feedf3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!65 &430065807486455890
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 118616}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 10, y: 2, z: 1.6}
+  m_Center: {x: 0, y: 1, z: 0}
 --- !u!1 &134962
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/PyroParticles/Prefab/Script/MeteorSwarmScript.cs
+++ b/Assets/PyroParticles/Prefab/Script/MeteorSwarmScript.cs
@@ -68,8 +68,6 @@ namespace DigitalRuby.PyroParticles
 
         private IEnumerator SpawnMeteor()
         {
-            //Source = GameObject.FindGameObjectWithTag("Player").transform.position + new Vector3(0, 100, 0);
-
             {
                 float delay = UnityEngine.Random.Range(0.0f, 1.0f);
                 yield return new WaitForSeconds(delay);

--- a/Assets/PyroParticles/Prefab/Script/MeteorSwarmScript.cs
+++ b/Assets/PyroParticles/Prefab/Script/MeteorSwarmScript.cs
@@ -34,8 +34,8 @@ namespace DigitalRuby.PyroParticles
         [Tooltip("The destination radius")]
         public float DestinationRadius;
 
-        [Tooltip("The source of the meteor swarm (in the sky somewhere usually)")]
-        public Vector3 Source;
+        [Tooltip("The height from which the meteor swarm will spawn")]
+        public float SpawnHeight;
 
         [Tooltip("The source radius")]
         public float SourceRadius;
@@ -68,13 +68,15 @@ namespace DigitalRuby.PyroParticles
 
         private IEnumerator SpawnMeteor()
         {
+            //Source = GameObject.FindGameObjectWithTag("Player").transform.position + new Vector3(0, 100, 0);
+
             {
                 float delay = UnityEngine.Random.Range(0.0f, 1.0f);
                 yield return new WaitForSeconds(delay);
             }
 
             // find a random source and destination point within the specified radius
-            Vector3 src = Source + (UnityEngine.Random.insideUnitSphere * SourceRadius);
+            Vector3 src = transform.position + new Vector3(0, SpawnHeight, 0) + (UnityEngine.Random.insideUnitSphere * SourceRadius);
             GameObject meteor = GameObject.Instantiate(MeteorPrefab);
             float scale = UnityEngine.Random.Range(ScaleRange.Minimum, ScaleRange.Maximum);
             meteor.transform.localScale = new Vector3(scale, scale, scale);

--- a/Assets/Scripts/Entity/Enemy/Boss/PhaseTwo.cs
+++ b/Assets/Scripts/Entity/Enemy/Boss/PhaseTwo.cs
@@ -51,7 +51,7 @@ public class PhaseTwo : MonoBehaviour
         // Meteor attack
         if (phaseTwoAttackTimer > timeToPhaseTwoAttack)
         {
-            Instantiate(phaseTwoAttack, gameObject.transform);
+            Instantiate(phaseTwoAttack, GameObject.FindGameObjectWithTag("Player").transform);
             phaseTwoAttackTimer = 0.0f;
         }
     }


### PR DESCRIPTION
Related issue: #78 

Summary of major changes:

- Slightly increased the rate at which the player's model flashes during invincibility.

- Significantly reduced the number of meteors that spawn per second, as well as the radius in which they spawn. This should help minimize lag and make it a little easier to survive the strikes.

- Changed the meteor spawn position so they don't arrive at an angle. Previously, they spawned at a fixed vector in space and would strike the room at an angle from the sky. This meant you could hug the lower wall and it would shield you from the meteors. Now, they come down straight from above the player.

- The wall of fire now has a collider and fire script to damage the player. **TODO/visual bug: ** Because of the camera angle, some of the walls of fire (such as the one along the top wall and the one along the right wall) do not register visually, even though they're there.

- Colliders on the meteors and small fires were increased slightly to better reflect actual contact with the player.