### PR TITLE
Fix boss health race condition

### DIFF
--- a/Assets/Scripts/Environmental/UI/BossHealth.cs
+++ b/Assets/Scripts/Environmental/UI/BossHealth.cs
@@ -19,6 +19,7 @@ public class BossHealth : MonoBehaviour
      */ 
     private void Awake()
     {
+        slider = gameObject.GetComponent<Slider>();
         Boss.bossBattleStarted += AssociateWithLevelBoss;
         defaultScale = gameObject.transform.localScale;
 
@@ -54,7 +55,6 @@ public class BossHealth : MonoBehaviour
             boss.healthChangedEvent += OnBossHealthChanged;
             boss.deathEvent += OnBossDied;
 
-            slider = gameObject.GetComponent<Slider>();
             slider.maxValue = boss.MaxHealth;
             slider.minValue = 0;
             slider.value = slider.maxValue;


### PR DESCRIPTION
`slider` is a field of BossHealth, and I accidentally assigned the reference in `AssociateWithLevelBoss` instead of in `Awake`

the way the order is here means there will occasionally be a race condition, where we subscribe to the health changed event and try to update the slider value before the slider is ever actually initialized