### PR TITLE
Fix issue where restart would break the boss battle.

### DIFF
--- a/Assets/Scripts/Environmental/UI/BossHealth.cs
+++ b/Assets/Scripts/Environmental/UI/BossHealth.cs
@@ -28,10 +28,6 @@ public class BossHealth : MonoBehaviour
         defaultScale = gameObject.transform.localScale;
 
         Hide();
-
-        Debug.Log("Started!");
-        Debug.Log("Game object transform: " + (gameObject.transform) == null);
-        Debug.Log("Scale: " + defaultScale);
     }
 
 

--- a/Assets/Scripts/Environmental/UI/BossHealth.cs
+++ b/Assets/Scripts/Environmental/UI/BossHealth.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
+using UnityEngine.SceneManagement;
+
 
 public class BossHealth : MonoBehaviour
 {
@@ -17,13 +19,19 @@ public class BossHealth : MonoBehaviour
 
     /* Perform all necessary setup for the health management.
      */ 
-    private void Awake()
+    private void Start()
     {
+        SceneManager.activeSceneChanged += OnSceneChanged;
+
         slider = gameObject.GetComponent<Slider>();
         Boss.bossBattleStarted += AssociateWithLevelBoss;
         defaultScale = gameObject.transform.localScale;
 
         Hide();
+
+        Debug.Log("Started!");
+        Debug.Log("Game object transform: " + (gameObject.transform) == null);
+        Debug.Log("Scale: " + defaultScale);
     }
 
 
@@ -79,5 +87,16 @@ public class BossHealth : MonoBehaviour
         boss.healthChangedEvent -= OnBossHealthChanged;
         boss = null;
         Hide();
+    }
+
+
+    /* Called when the scene changes. Required for unsubscribing from the
+     * previous static boss signal before the scene is loaded, since it
+     * would persist and attempt to call AssociateWithLevelBoss in a
+     * version of the game object that was destroyed upon scene change.
+     */ 
+    private void OnSceneChanged(Scene prev, Scene next)
+    {
+        Boss.bossBattleStarted -= AssociateWithLevelBoss;
     }
 }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -9,7 +9,7 @@ using UnityEngine.UI;
 public class GameManager : MonoBehaviour
 {
     // Internal flag to keep track of whether the user has paused
-    public static bool gameIsPaused = false;
+    public bool gameIsPaused = false;
 
     // Reference to the player
     [SerializeField] private Player player;
@@ -85,9 +85,6 @@ public class GameManager : MonoBehaviour
      */ 
     public void Restart()
     {
-        // Necessary because it's  and persists
-        gameIsPaused = false;
-
         Time.timeScale = 1f;
         LevelIntro.nameOfSceneToLoad = "Level1";
         SceneManager.LoadScene("LevelIntro");
@@ -98,9 +95,6 @@ public class GameManager : MonoBehaviour
      */ 
     public void LoadMenu()
     {
-        // Necessary because it's  and persists
-        gameIsPaused = false;
-
         Time.timeScale = 1f;
         SceneManager.LoadScene("Menu");
     }


### PR DESCRIPTION
Restarting the game or going to the menu no longer breaks the BossHealth script.

The issue was that the `Boss` class's static event (`bossBattleStarted`) persists across scene changes, and the `BossHealth` script did not unsubscribe from this event when the active scene changed.

Effectively, this meant that when the boss spawned in and triggered its event, an older version of `AssociateWithLevel` associated with the already deleted script was getting called (hence the `MissingReferenceException` for the game object).

If that makes sense?