### PR TITLE
Fix bug where the player wouldnt animate after possess

### DIFF
--- a/Assets/Scripts/Entity/Player/Possession.cs
+++ b/Assets/Scripts/Entity/Player/Possession.cs
@@ -101,26 +101,23 @@ public class Possession : MonoBehaviour
         player.SetModel(newModel);
         player.GetComponent<IWeaponController>().SetWeaponInstance(newWeapon);
         
-        // Notify any OnPossession controllers of the possesssion before cleanup
-        NotifyOnPossessionControllers(enemy);
-        
         //Cleanup
+        // Detach the model and weapons
+        currentPlayerModel.transform.SetParent(null);
+        playerWeapon.transform.SetParent(null);
+        // Destroy the objects
         Destroy(currentPlayerModel);
         Destroy(playerWeapon);
         Destroy(enemy);
         
+        // Notify any OnPossession controllers of the possesssion
+        NotifyOnPossessionControllers();
     }
 
-    private void NotifyOnPossessionControllers(GameObject enemy)
+    private void NotifyOnPossessionControllers()
     {
         // Notify player controllers
         foreach(IOnPossessionController iopc in GetComponents<IOnPossessionController>())
-        {
-            iopc.OnPossession();
-        }
-        
-        // Notify enemy controllers
-        foreach(IOnPossessionController iopc in enemy.GetComponents<IOnPossessionController>())
         {
             iopc.OnPossession();
         }


### PR DESCRIPTION
Not exactly sure why this bug was occuring but I did find out
that the player had two models (old one and new one) in it's
hierarchy immediately after possession. Even after the destroy
methods were called on the model, it was still there (I assume
the actual destroy was occuring 1 or 2 frames later). This caused
the previous model's animator to be referenced into ani, which would
only get destroyed and thus no animation would play on the player.