### PR TITLE
Player detection

### DIFF
--- a/Assets/Prefabs/Enemy/CruzEnemy.prefab
+++ b/Assets/Prefabs/Enemy/CruzEnemy.prefab
@@ -50,6 +50,7 @@ GameObject:
   - component: {fileID: 1016939505879649357}
   - component: {fileID: 1016939505879649358}
   - component: {fileID: 688633171}
+  - component: {fileID: 713458984421162947}
   m_Layer: 0
   m_Name: CruzEnemy
   m_TagString: Enemy
@@ -70,6 +71,7 @@ Transform:
   m_Children:
   - {fileID: 1016939505023120830}
   - {fileID: 3832820618763950501}
+  - {fileID: 4569331105536973329}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -229,6 +231,22 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 112
   m_CollisionDetection: 0
+--- !u!208 &713458984421162947
+NavMeshObstacle:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1016939505879649359}
+  m_Enabled: 0
+  serializedVersion: 3
+  m_Shape: 1
+  m_Extents: {x: 0.5, y: 0.5, z: 0.5}
+  m_MoveThreshold: 0.1
+  m_Carve: 1
+  m_CarveOnlyStationary: 1
+  m_Center: {x: 0, y: 0, z: 0}
+  m_TimeToStationary: 0.5
 --- !u!1001 &1016939506656112075
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -236,6 +254,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1016939505023120830}
     m_Modifications:
+    - target: {fileID: 100044, guid: 7b8cf766c639f374c8e9dade4e5c115a, type: 3}
+      propertyPath: m_Name
+      value: CruzModel
+      objectReference: {fileID: 0}
     - target: {fileID: 400044, guid: 7b8cf766c639f374c8e9dade4e5c115a, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -279,10 +301,6 @@ PrefabInstance:
     - target: {fileID: 400044, guid: 7b8cf766c639f374c8e9dade4e5c115a, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 100044, guid: 7b8cf766c639f374c8e9dade4e5c115a, type: 3}
-      propertyPath: m_Name
-      value: CruzModel
       objectReference: {fileID: 0}
     - target: {fileID: 9500000, guid: 7b8cf766c639f374c8e9dade4e5c115a, type: 3}
       propertyPath: m_Controller
@@ -565,4 +583,79 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 4263799561533925866, guid: c6ae13810cb4779489b28e4911abdf7b,
     type: 3}
   m_PrefabInstance: {fileID: 1016939507112865865}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1900357970238399417
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1016939505879649366}
+    m_Modifications:
+    - target: {fileID: 5910678455572633873, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_Name
+      value: PlayerDetector
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fd4678c5ba2ce144fb028970faca87d8, type: 3}
+--- !u!4 &4569331105536973329 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+    type: 3}
+  m_PrefabInstance: {fileID: 1900357970238399417}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/Enemy/CubexEnemy.prefab
+++ b/Assets/Prefabs/Enemy/CubexEnemy.prefab
@@ -477,6 +477,7 @@ GameObject:
   - component: {fileID: 4007304483517652784}
   - component: {fileID: 4007304483517652787}
   - component: {fileID: 2156721400152459280}
+  - component: {fileID: 4355080717287252048}
   m_Layer: 0
   m_Name: CubexEnemy
   m_TagString: Enemy
@@ -497,6 +498,7 @@ Transform:
   m_Children:
   - {fileID: 8946576197557858831}
   - {fileID: 8278483085797384673}
+  - {fileID: 2268227684980603274}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -580,7 +582,7 @@ NavMeshAgent:
   m_Speed: 2
   m_Acceleration: 8
   avoidancePriority: 50
-  m_AngularSpeed: 200
+  m_AngularSpeed: 300
   m_StoppingDistance: 0
   m_AutoTraverseOffMeshLink: 1
   m_AutoBraking: 1
@@ -657,6 +659,22 @@ MonoBehaviour:
   xzRange: 600
   yForce: 800
   spawnHeight: 2.5
+--- !u!208 &4355080717287252048
+NavMeshObstacle:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4007304483517652786}
+  m_Enabled: 0
+  serializedVersion: 3
+  m_Shape: 1
+  m_Extents: {x: 0.5, y: 0.5, z: 0.5}
+  m_MoveThreshold: 0.1
+  m_Carve: 1
+  m_CarveOnlyStationary: 1
+  m_Center: {x: 0, y: 0, z: 0}
+  m_TimeToStationary: 0.5
 --- !u!1 &8278483084363579293
 GameObject:
   m_ObjectHideFlags: 0
@@ -791,3 +809,78 @@ MonoBehaviour:
   projectileLifetime: 5
   forwardOffset: 0.5
   upwardOffset: 0
+--- !u!1001 &4200933629451386914
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 4007304483517652792}
+    m_Modifications:
+    - target: {fileID: 5910678455572633873, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_Name
+      value: PlayerDetector
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fd4678c5ba2ce144fb028970faca87d8, type: 3}
+--- !u!4 &2268227684980603274 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+    type: 3}
+  m_PrefabInstance: {fileID: 4200933629451386914}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/Enemy/KatEnemy.prefab
+++ b/Assets/Prefabs/Enemy/KatEnemy.prefab
@@ -19,6 +19,7 @@ GameObject:
   - component: {fileID: 2506059092821221657}
   - component: {fileID: 2506059092821221653}
   - component: {fileID: 5960857235701816549}
+  - component: {fileID: 1940189648801771835}
   m_Layer: 0
   m_Name: KatEnemy
   m_TagString: Enemy
@@ -39,6 +40,7 @@ Transform:
   m_Children:
   - {fileID: 2506059094071796184}
   - {fileID: 5401922665690171401}
+  - {fileID: 6662699218567891470}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -199,6 +201,22 @@ MonoBehaviour:
   xzRange: 600
   yForce: 800
   spawnHeight: 2.5
+--- !u!208 &1940189648801771835
+NavMeshObstacle:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2506059092821221663}
+  m_Enabled: 0
+  serializedVersion: 3
+  m_Shape: 1
+  m_Extents: {x: 0.5, y: 0.5, z: 0.5}
+  m_MoveThreshold: 0.1
+  m_Carve: 1
+  m_CarveOnlyStationary: 1
+  m_Center: {x: 0, y: 0, z: 0}
+  m_TimeToStationary: 0.5
 --- !u!1001 &2506059093331976648
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -302,6 +320,14 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 2506059092821221662}
     m_Modifications:
+    - target: {fileID: 100014, guid: 2c24a6dcb26e611469ede5df25420229, type: 3}
+      propertyPath: m_Name
+      value: KatEnemyModel
+      objectReference: {fileID: 0}
+    - target: {fileID: 100010, guid: 2c24a6dcb26e611469ede5df25420229, type: 3}
+      propertyPath: m_Name
+      value: SimpleEnemyModel
+      objectReference: {fileID: 0}
     - target: {fileID: 400014, guid: 2c24a6dcb26e611469ede5df25420229, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -345,14 +371,6 @@ PrefabInstance:
     - target: {fileID: 400014, guid: 2c24a6dcb26e611469ede5df25420229, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 100014, guid: 2c24a6dcb26e611469ede5df25420229, type: 3}
-      propertyPath: m_Name
-      value: KatEnemyModel
-      objectReference: {fileID: 0}
-    - target: {fileID: 100010, guid: 2c24a6dcb26e611469ede5df25420229, type: 3}
-      propertyPath: m_Name
-      value: SimpleEnemyModel
       objectReference: {fileID: 0}
     - target: {fileID: 400010, guid: 2c24a6dcb26e611469ede5df25420229, type: 3}
       propertyPath: m_LocalRotation.y
@@ -417,4 +435,79 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 400006, guid: 2c24a6dcb26e611469ede5df25420229,
     type: 3}
   m_PrefabInstance: {fileID: 2506059094072195926}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8737056174312780710
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2506059092821221662}
+    m_Modifications:
+    - target: {fileID: 5910678455572633873, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_Name
+      value: PlayerDetector
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fd4678c5ba2ce144fb028970faca87d8, type: 3}
+--- !u!4 &6662699218567891470 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+    type: 3}
+  m_PrefabInstance: {fileID: 8737056174312780710}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/Enemy/PlayerDetector.prefab
+++ b/Assets/Prefabs/Enemy/PlayerDetector.prefab
@@ -1,0 +1,76 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5910678455572633873
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2681590040891029928}
+  - component: {fileID: 3660620607879213593}
+  - component: {fileID: 5523546276374563866}
+  - component: {fileID: 8627988425070214878}
+  m_Layer: 0
+  m_Name: PlayerDetector
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2681590040891029928
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5910678455572633873}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &3660620607879213593
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5910678455572633873}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 6, y: 0.05, z: 20}
+  m_Center: {x: 0, y: -0.5, z: 6}
+--- !u!54 &5523546276374563866
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5910678455572633873}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!114 &8627988425070214878
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5910678455572633873}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2bf13059866adf44e995ce57cf033022, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/Enemy/PlayerDetector.prefab.meta
+++ b/Assets/Prefabs/Enemy/PlayerDetector.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: fd4678c5ba2ce144fb028970faca87d8
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Enemy/TentiEnemy.prefab
+++ b/Assets/Prefabs/Enemy/TentiEnemy.prefab
@@ -48,6 +48,7 @@ GameObject:
   - component: {fileID: 6004890344381659933}
   - component: {fileID: 6004890344381659906}
   - component: {fileID: 5384902669632447286}
+  - component: {fileID: 2026874264386177931}
   m_Layer: 0
   m_Name: TentiEnemy
   m_TagString: Enemy
@@ -68,6 +69,7 @@ Transform:
   m_Children:
   - {fileID: 6004890343367689407}
   - {fileID: 1792985049925869951}
+  - {fileID: 7719705365436434753}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -200,6 +202,107 @@ NavMeshAgent:
   m_BaseOffset: 1
   m_WalkableMask: 4294967295
   m_ObstacleAvoidanceType: 4
+--- !u!208 &2026874264386177931
+NavMeshObstacle:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6004890344381659904}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Shape: 1
+  m_Extents: {x: 0.5, y: 0.5, z: 0.5}
+  m_MoveThreshold: 0.1
+  m_Carve: 1
+  m_CarveOnlyStationary: 1
+  m_Center: {x: 0, y: 0, z: 0}
+  m_TimeToStationary: 0.5
+--- !u!1001 &5626980339148452073
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 6004890344381659928}
+    m_Modifications:
+    - target: {fileID: 5910678455572633873, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_Name
+      value: PlayerDetector
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3660620607879213593, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_Size.z
+      value: 40
+      objectReference: {fileID: 0}
+    - target: {fileID: 3660620607879213593, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_Center.z
+      value: 20
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fd4678c5ba2ce144fb028970faca87d8, type: 3}
+--- !u!4 &7719705365436434753 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+    type: 3}
+  m_PrefabInstance: {fileID: 5626980339148452073}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &6004890343530054663
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -373,18 +476,6 @@ PrefabInstance:
       objectReference: {fileID: 6004890343530454663}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b27c6c6bc8c85cc488a6801c92ed4f69, type: 3}
---- !u!4 &6004890343530454663 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 400000, guid: b27c6c6bc8c85cc488a6801c92ed4f69,
-    type: 3}
-  m_PrefabInstance: {fileID: 6004890343530054663}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &6004890343530454685 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 400026, guid: b27c6c6bc8c85cc488a6801c92ed4f69,
-    type: 3}
-  m_PrefabInstance: {fileID: 6004890343530054663}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &6004890343530454703 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 400040, guid: b27c6c6bc8c85cc488a6801c92ed4f69,
@@ -505,9 +596,9 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 6004890343530054663}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &6004890343530454709 stripped
+--- !u!4 &6004890343530454715 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 400050, guid: b27c6c6bc8c85cc488a6801c92ed4f69,
+  m_CorrespondingSourceObject: {fileID: 400060, guid: b27c6c6bc8c85cc488a6801c92ed4f69,
     type: 3}
   m_PrefabInstance: {fileID: 6004890343530054663}
   m_PrefabAsset: {fileID: 0}
@@ -535,9 +626,21 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 6004890343530054663}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &6004890343530454715 stripped
+--- !u!4 &6004890343530454709 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 400060, guid: b27c6c6bc8c85cc488a6801c92ed4f69,
+  m_CorrespondingSourceObject: {fileID: 400050, guid: b27c6c6bc8c85cc488a6801c92ed4f69,
+    type: 3}
+  m_PrefabInstance: {fileID: 6004890343530054663}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &6004890343530454663 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 400000, guid: b27c6c6bc8c85cc488a6801c92ed4f69,
+    type: 3}
+  m_PrefabInstance: {fileID: 6004890343530054663}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &6004890343530454685 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 400026, guid: b27c6c6bc8c85cc488a6801c92ed4f69,
     type: 3}
   m_PrefabInstance: {fileID: 6004890343530054663}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/Enemy/TentiEnemyBurst.prefab
+++ b/Assets/Prefabs/Enemy/TentiEnemyBurst.prefab
@@ -48,6 +48,7 @@ GameObject:
   - component: {fileID: 124331789069296918}
   - component: {fileID: 124331789069296905}
   - component: {fileID: 1753893236251278653}
+  - component: {fileID: 4301493831995270355}
   m_Layer: 0
   m_Name: TentiEnemyBurst
   m_TagString: Enemy
@@ -68,6 +69,7 @@ Transform:
   m_Children:
   - {fileID: 124331788005006004}
   - {fileID: 6431010278533982372}
+  - {fileID: 7484232106145567951}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -200,6 +202,22 @@ NavMeshAgent:
   m_BaseOffset: 1
   m_WalkableMask: 4294967295
   m_ObstacleAvoidanceType: 4
+--- !u!208 &4301493831995270355
+NavMeshObstacle:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 124331789069296907}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Shape: 1
+  m_Extents: {x: 0.5, y: 0.5, z: 0.5}
+  m_MoveThreshold: 0.1
+  m_Carve: 1
+  m_CarveOnlyStationary: 1
+  m_Center: {x: 0, y: 0, z: 0}
+  m_TimeToStationary: 0.5
 --- !u!1001 &124331788309977612
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -540,6 +558,91 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 400060, guid: b27c6c6bc8c85cc488a6801c92ed4f69,
     type: 3}
   m_PrefabInstance: {fileID: 124331788309977612}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &4822157410702044519
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 124331789069296915}
+    m_Modifications:
+    - target: {fileID: 5910678455572633873, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_Name
+      value: PlayerDetector
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3660620607879213593, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_Size.z
+      value: 40
+      objectReference: {fileID: 0}
+    - target: {fileID: 3660620607879213593, guid: fd4678c5ba2ce144fb028970faca87d8,
+        type: 3}
+      propertyPath: m_Center.z
+      value: 20
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fd4678c5ba2ce144fb028970faca87d8, type: 3}
+--- !u!4 &7484232106145567951 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2681590040891029928, guid: fd4678c5ba2ce144fb028970faca87d8,
+    type: 3}
+  m_PrefabInstance: {fileID: 4822157410702044519}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &5559678245148223891
 PrefabInstance:

--- a/Assets/Prefabs/Player/MainPlayer.prefab
+++ b/Assets/Prefabs/Player/MainPlayer.prefab
@@ -257,6 +257,11 @@ PrefabInstance:
       propertyPath: upwardOffset
       value: 0.4
       objectReference: {fileID: 0}
+    - target: {fileID: 5455074748802241686, guid: 81daa4c07a3b70c498f863d39a24b47e,
+        type: 3}
+      propertyPath: projectileLifetime
+      value: 3
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 81daa4c07a3b70c498f863d39a24b47e, type: 3}
 --- !u!1 &8985372404558189384 stripped

--- a/Assets/Prefabs/Traps/Rock/Rock.prefab
+++ b/Assets/Prefabs/Traps/Rock/Rock.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2850494099741027293}
   - component: {fileID: 6728772714929971869}
+  - component: {fileID: 136873645265487867}
   m_Layer: 0
   m_Name: Rock
   m_TagString: Wall
@@ -46,6 +47,22 @@ CapsuleCollider:
   m_Height: 1
   m_Direction: 1
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!208 &136873645265487867
+NavMeshObstacle:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1621663522658202865}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Shape: 1
+  m_Extents: {x: 175, y: 175, z: 200}
+  m_MoveThreshold: 0.1
+  m_Carve: 1
+  m_CarveOnlyStationary: 1
+  m_Center: {x: 0, y: 0, z: 0}
+  m_TimeToStationary: 0.5
 --- !u!1 &7279928986277566266
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Official/Level1.unity
+++ b/Assets/Scenes/Official/Level1.unity
@@ -187,6 +187,96 @@ PrefabInstance:
         type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6cb40b2cf0e5a444bb3d122b576da6ac, type: 3}
+--- !u!1001 &34154674
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1987691335}
+    m_Modifications:
+    - target: {fileID: 1621663522658202865, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_Name
+      value: Rock (40)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -50.29
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.27
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -21.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 36
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.005
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1071c54b741cceb41be379917012658d, type: 3}
+--- !u!4 &34154675 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+    type: 3}
+  m_PrefabInstance: {fileID: 34154674}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &50336761
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1219,6 +1309,96 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 205943642}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &223655838
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1987691335}
+    m_Modifications:
+    - target: {fileID: 1621663522658202865, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_Name
+      value: Rock (36)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -53.72
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.27
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -14.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 32
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.005
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1071c54b741cceb41be379917012658d, type: 3}
+--- !u!4 &223655839 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+    type: 3}
+  m_PrefabInstance: {fileID: 223655838}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &224991740
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1841,6 +2021,96 @@ PrefabInstance:
         type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6cb40b2cf0e5a444bb3d122b576da6ac, type: 3}
+--- !u!1001 &385515002
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1987691335}
+    m_Modifications:
+    - target: {fileID: 1621663522658202865, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_Name
+      value: Rock (47)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -26.72
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.27
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -25.19
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 43
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.005
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1071c54b741cceb41be379917012658d, type: 3}
+--- !u!4 &385515003 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+    type: 3}
+  m_PrefabInstance: {fileID: 385515002}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &406854427
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2144,6 +2414,186 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 415016, guid: afd19ab1d4bb70b499bb2f62171a522d,
     type: 3}
   m_PrefabInstance: {fileID: 431852763}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &448379842
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1987691335}
+    m_Modifications:
+    - target: {fileID: 1621663522658202865, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_Name
+      value: Rock (37)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -53.97
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.27
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -16.33
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 33
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.005
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1071c54b741cceb41be379917012658d, type: 3}
+--- !u!4 &448379843 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+    type: 3}
+  m_PrefabInstance: {fileID: 448379842}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &454820028
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1987691335}
+    m_Modifications:
+    - target: {fileID: 1621663522658202865, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_Name
+      value: Rock (42)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -54.56
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.27
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -22.31
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 38
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.005
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1071c54b741cceb41be379917012658d, type: 3}
+--- !u!4 &454820029 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+    type: 3}
+  m_PrefabInstance: {fileID: 454820028}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &455262455
 PrefabInstance:
@@ -2482,7 +2932,7 @@ PrefabInstance:
     - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
         type: 3}
       propertyPath: m_RootOrder
-      value: 28
+      value: 25
       objectReference: {fileID: 0}
     - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
         type: 3}
@@ -2686,6 +3136,96 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 8316170259260908323, guid: bd6d38f092a20524cbb893325e78777b,
     type: 3}
   m_PrefabInstance: {fileID: 50336761}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &624780322
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1987691335}
+    m_Modifications:
+    - target: {fileID: 1621663522658202865, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_Name
+      value: Rock (41)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -52.36
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.27
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -21.03
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 37
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.005
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1071c54b741cceb41be379917012658d, type: 3}
+--- !u!4 &624780323 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+    type: 3}
+  m_PrefabInstance: {fileID: 624780322}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &626565164
 PrefabInstance:
@@ -3582,7 +4122,7 @@ PrefabInstance:
     - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
         type: 3}
       propertyPath: m_RootOrder
-      value: 27
+      value: 24
       objectReference: {fileID: 0}
     - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
         type: 3}
@@ -3777,6 +4317,96 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 224198badb8d31847a3ab6b59ec2d3ff, type: 3}
+--- !u!1001 &802434550
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1987691335}
+    m_Modifications:
+    - target: {fileID: 1621663522658202865, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_Name
+      value: Rock (44)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -31.04
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.27
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -21.51
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 40
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.005
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1071c54b741cceb41be379917012658d, type: 3}
+--- !u!4 &802434551 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+    type: 3}
+  m_PrefabInstance: {fileID: 802434550}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &806855374
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3981,6 +4611,96 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 8316170259252831861, guid: bd6d38f092a20524cbb893325e78777b,
     type: 3}
   m_PrefabInstance: {fileID: 812398915}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &879230418
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1987691335}
+    m_Modifications:
+    - target: {fileID: 1621663522658202865, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_Name
+      value: Rock (38)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -50.29
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.27
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -17.34
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 34
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.005
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1071c54b741cceb41be379917012658d, type: 3}
+--- !u!4 &879230419 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+    type: 3}
+  m_PrefabInstance: {fileID: 879230418}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &893282940
 PrefabInstance:
@@ -4336,7 +5056,7 @@ PrefabInstance:
     - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
         type: 3}
       propertyPath: m_RootOrder
-      value: 30
+      value: 27
       objectReference: {fileID: 0}
     - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
         type: 3}
@@ -4916,7 +5636,7 @@ PrefabInstance:
     - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
         type: 3}
       propertyPath: m_RootOrder
-      value: 29
+      value: 26
       objectReference: {fileID: 0}
     - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
         type: 3}
@@ -5908,6 +6628,186 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1206068637}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1249779567
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1987691335}
+    m_Modifications:
+    - target: {fileID: 1621663522658202865, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_Name
+      value: Rock (39)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -52.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.27
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -17.17
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.8870109
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.46174863
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 35
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -125
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.005
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1071c54b741cceb41be379917012658d, type: 3}
+--- !u!4 &1249779568 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+    type: 3}
+  m_PrefabInstance: {fileID: 1249779567}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1275336785
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1987691335}
+    m_Modifications:
+    - target: {fileID: 1621663522658202865, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_Name
+      value: Rock (45)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -29.19
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.27
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -21.72
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 41
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.005
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1071c54b741cceb41be379917012658d, type: 3}
+--- !u!4 &1275336786 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+    type: 3}
+  m_PrefabInstance: {fileID: 1275336785}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1339805629
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6478,6 +7378,96 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1501089411}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1509393422
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1987691335}
+    m_Modifications:
+    - target: {fileID: 1621663522658202865, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_Name
+      value: Rock (46)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -26.88
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.27
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -22.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 42
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.005
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1071c54b741cceb41be379917012658d, type: 3}
+--- !u!4 &1509393423 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+    type: 3}
+  m_PrefabInstance: {fileID: 1509393422}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1509434731
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6629,6 +7619,96 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 8316170259260908323, guid: bd6d38f092a20524cbb893325e78777b,
     type: 3}
   m_PrefabInstance: {fileID: 952968807}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1576519042
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1987691335}
+    m_Modifications:
+    - target: {fileID: 1621663522658202865, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_Name
+      value: Rock (33)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -27.46
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.27
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -16.33
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 29
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.005
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1071c54b741cceb41be379917012658d, type: 3}
+--- !u!4 &1576519043 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+    type: 3}
+  m_PrefabInstance: {fileID: 1576519042}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1583164619
 PrefabInstance:
@@ -7172,7 +8252,7 @@ PrefabInstance:
     - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
         type: 3}
       propertyPath: m_RootOrder
-      value: 26
+      value: 23
       objectReference: {fileID: 0}
     - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
         type: 3}
@@ -7405,6 +8485,96 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 389151889606449708, guid: 587e9341cf930bc468dfe8b3c926228e,
     type: 3}
   m_PrefabInstance: {fileID: 1679017617}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1681314841
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1987691335}
+    m_Modifications:
+    - target: {fileID: 1621663522658202865, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_Name
+      value: Rock (32)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -27.46
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.27
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -14.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 28
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.005
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1071c54b741cceb41be379917012658d, type: 3}
+--- !u!4 &1681314842 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+    type: 3}
+  m_PrefabInstance: {fileID: 1681314841}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &1690022736
 GameObject:
@@ -8022,6 +9192,96 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1842240319}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1853296131
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1987691335}
+    m_Modifications:
+    - target: {fileID: 1621663522658202865, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_Name
+      value: Rock (35)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -31.04
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.27
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -17.17
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.8870109
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.46174863
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 31
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -125
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.005
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1071c54b741cceb41be379917012658d, type: 3}
+--- !u!4 &1853296132 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+    type: 3}
+  m_PrefabInstance: {fileID: 1853296131}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1859628807
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -8072,7 +9332,7 @@ PrefabInstance:
     - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
         type: 3}
       propertyPath: m_RootOrder
-      value: 25
+      value: 22
       objectReference: {fileID: 0}
     - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
         type: 3}
@@ -8182,6 +9442,96 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 415016, guid: afd19ab1d4bb70b499bb2f62171a522d,
     type: 3}
   m_PrefabInstance: {fileID: 1871096650}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1871704772
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1987691335}
+    m_Modifications:
+    - target: {fileID: 1621663522658202865, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_Name
+      value: Rock (43)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -54.56
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.27
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -24.63
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 39
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.005
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1071c54b741cceb41be379917012658d, type: 3}
+--- !u!4 &1871704773 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+    type: 3}
+  m_PrefabInstance: {fileID: 1871704772}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1895381197
 PrefabInstance:
@@ -9037,6 +10387,22 @@ Transform:
   - {fileID: 547143748}
   - {fileID: 1013529727}
   - {fileID: 940492316}
+  - {fileID: 1681314842}
+  - {fileID: 1576519043}
+  - {fileID: 2088501196}
+  - {fileID: 1853296132}
+  - {fileID: 223655839}
+  - {fileID: 448379843}
+  - {fileID: 879230419}
+  - {fileID: 1249779568}
+  - {fileID: 34154675}
+  - {fileID: 624780323}
+  - {fileID: 454820029}
+  - {fileID: 1871704773}
+  - {fileID: 802434551}
+  - {fileID: 1275336786}
+  - {fileID: 1509393423}
+  - {fileID: 385515003}
   m_Father: {fileID: 1690022737}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -10208,6 +11574,96 @@ PrefabInstance:
         type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6cb40b2cf0e5a444bb3d122b576da6ac, type: 3}
+--- !u!1001 &2088501195
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1987691335}
+    m_Modifications:
+    - target: {fileID: 1621663522658202865, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_Name
+      value: Rock (34)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -29.29
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.27
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -17.34
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.005
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1071c54b741cceb41be379917012658d, type: 3}
+--- !u!4 &2088501196 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+    type: 3}
+  m_PrefabInstance: {fileID: 2088501195}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2106999428
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Official/Level1.unity
+++ b/Assets/Scenes/Official/Level1.unity
@@ -467,6 +467,96 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 59744383}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &74247833
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1987691335}
+    m_Modifications:
+    - target: {fileID: 1621663522658202865, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_Name
+      value: Rock (17)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -27.46
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.27
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 7.27
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.005
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1071c54b741cceb41be379917012658d, type: 3}
+--- !u!4 &74247834 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+    type: 3}
+  m_PrefabInstance: {fileID: 74247833}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &107507501
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2342,6 +2432,96 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 2086146802}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &547143747
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1987691335}
+    m_Modifications:
+    - target: {fileID: 1621663522658202865, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_Name
+      value: Rock (29)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -27.46
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.27
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -7.47
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 28
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.005
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1071c54b741cceb41be379917012658d, type: 3}
+--- !u!4 &547143748 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+    type: 3}
+  m_PrefabInstance: {fileID: 547143747}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &551350179
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3352,6 +3532,96 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 749033166}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &781778336
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1987691335}
+    m_Modifications:
+    - target: {fileID: 1621663522658202865, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_Name
+      value: Rock (28)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -27.46
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.27
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -5.13
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 27
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.005
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1071c54b741cceb41be379917012658d, type: 3}
+--- !u!4 &781778337 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+    type: 3}
+  m_PrefabInstance: {fileID: 781778336}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &786610356
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4016,6 +4286,96 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 939372578}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &940492315
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1987691335}
+    m_Modifications:
+    - target: {fileID: 1621663522658202865, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_Name
+      value: Rock (31)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -27.46
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.27
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -8.98
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.005
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1071c54b741cceb41be379917012658d, type: 3}
+--- !u!4 &940492316 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+    type: 3}
+  m_PrefabInstance: {fileID: 940492315}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &952968807
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4505,6 +4865,96 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 415016, guid: afd19ab1d4bb70b499bb2f62171a522d,
     type: 3}
   m_PrefabInstance: {fileID: 985045386}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1013529726
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1987691335}
+    m_Modifications:
+    - target: {fileID: 1621663522658202865, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_Name
+      value: Rock (30)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -27.46
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.27
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -6.28
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 29
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.005
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1071c54b741cceb41be379917012658d, type: 3}
+--- !u!4 &1013529727 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+    type: 3}
+  m_PrefabInstance: {fileID: 1013529726}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1041700027
 PrefabInstance:
@@ -5027,6 +5477,96 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5381350258763008392, guid: ca54bcc921cac41529dcedcef8c32390,
     type: 3}
   m_PrefabInstance: {fileID: 1096494502}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1118998997
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1987691335}
+    m_Modifications:
+    - target: {fileID: 1621663522658202865, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_Name
+      value: Rock (16)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -27.46
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.27
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 9.08
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.005
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1071c54b741cceb41be379917012658d, type: 3}
+--- !u!4 &1118998998 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+    type: 3}
+  m_PrefabInstance: {fileID: 1118998997}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1154336123
 PrefabInstance:
@@ -6417,6 +6957,96 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6cb40b2cf0e5a444bb3d122b576da6ac, type: 3}
+--- !u!1001 &1609377971
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1987691335}
+    m_Modifications:
+    - target: {fileID: 1621663522658202865, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_Name
+      value: Rock (20)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -27.46
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.27
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 3.48
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.005
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1071c54b741cceb41be379917012658d, type: 3}
+--- !u!4 &1609377972 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+    type: 3}
+  m_PrefabInstance: {fileID: 1609377971}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1612773828
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6492,6 +7122,96 @@ PrefabInstance:
         type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6cb40b2cf0e5a444bb3d122b576da6ac, type: 3}
+--- !u!1001 &1640599476
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1987691335}
+    m_Modifications:
+    - target: {fileID: 1621663522658202865, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_Name
+      value: Rock (27)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -27.46
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.27
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -4.03
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 26
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.005
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1071c54b741cceb41be379917012658d, type: 3}
+--- !u!4 &1640599477 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+    type: 3}
+  m_PrefabInstance: {fileID: 1640599476}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1646809701
 GameObject:
   m_ObjectHideFlags: 0
@@ -6793,6 +7513,96 @@ PrefabInstance:
         type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6cb40b2cf0e5a444bb3d122b576da6ac, type: 3}
+--- !u!1001 &1734892280
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1987691335}
+    m_Modifications:
+    - target: {fileID: 1621663522658202865, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_Name
+      value: Rock (21)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -27.46
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.27
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.32
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.005
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1071c54b741cceb41be379917012658d, type: 3}
+--- !u!4 &1734892281 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+    type: 3}
+  m_PrefabInstance: {fileID: 1734892280}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1746347623
 GameObject:
   m_ObjectHideFlags: 0
@@ -7212,6 +8022,96 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1842240319}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1859628807
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1987691335}
+    m_Modifications:
+    - target: {fileID: 1621663522658202865, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_Name
+      value: Rock (26)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -27.46
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.27
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.77
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 25
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.005
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1071c54b741cceb41be379917012658d, type: 3}
+--- !u!4 &1859628808 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+    type: 3}
+  m_PrefabInstance: {fileID: 1859628807}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1871096650
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7282,6 +8182,96 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 415016, guid: afd19ab1d4bb70b499bb2f62171a522d,
     type: 3}
   m_PrefabInstance: {fileID: 1871096650}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1895381197
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1987691335}
+    m_Modifications:
+    - target: {fileID: 1621663522658202865, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_Name
+      value: Rock (18)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -27.46
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.27
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 5.78
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 18
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.005
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1071c54b741cceb41be379917012658d, type: 3}
+--- !u!4 &1895381198 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+    type: 3}
+  m_PrefabInstance: {fileID: 1895381197}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1896117542
 PrefabInstance:
@@ -7827,6 +8817,96 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1928854207}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1964523047
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1987691335}
+    m_Modifications:
+    - target: {fileID: 1621663522658202865, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_Name
+      value: Rock (19)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -27.46
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.27
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.66
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 19
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.005
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1071c54b741cceb41be379917012658d, type: 3}
+--- !u!4 &1964523048 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2850494099741027293, guid: 1071c54b741cceb41be379917012658d,
+    type: 3}
+  m_PrefabInstance: {fileID: 1964523047}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1976741887
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7945,6 +9025,18 @@ Transform:
   - {fileID: 2009066909}
   - {fileID: 120363904}
   - {fileID: 1067900150}
+  - {fileID: 1118998998}
+  - {fileID: 74247834}
+  - {fileID: 1895381198}
+  - {fileID: 1964523048}
+  - {fileID: 1609377972}
+  - {fileID: 1734892281}
+  - {fileID: 1859628808}
+  - {fileID: 1640599477}
+  - {fileID: 781778337}
+  - {fileID: 547143748}
+  - {fileID: 1013529727}
+  - {fileID: 940492316}
   m_Father: {fileID: 1690022737}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scripts/Entity/Enemy/AIAttackController.cs
+++ b/Assets/Scripts/Entity/Enemy/AIAttackController.cs
@@ -14,6 +14,7 @@ public class AIAttackController : MonoBehaviour, IOnDeathController
 
     void Awake()
     {
+        enabled = false;
         sc = GetComponent<ShootController>(); // Should be an AttackController interface
     }
 

--- a/Assets/Scripts/Entity/Enemy/DetectPlayer.cs
+++ b/Assets/Scripts/Entity/Enemy/DetectPlayer.cs
@@ -45,7 +45,6 @@ public class DetectPlayer : MonoBehaviour
         {
             if (hit.transform.gameObject.CompareTag("Player"))
             {
-                Debug.Log("No obstacles between player and enemy. Fire!");
                 attackController.enabled = true;
             }
         }

--- a/Assets/Scripts/Entity/Enemy/DetectPlayer.cs
+++ b/Assets/Scripts/Entity/Enemy/DetectPlayer.cs
@@ -1,0 +1,71 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+
+public class DetectPlayer : MonoBehaviour
+{
+    // Parent object of this controller
+    private GameObject parentObject;
+
+    // Reference to the attack controller script dictating when the AI attacks
+    private AIAttackController attackController;
+
+    // Reference to the box collider used to detect the player
+    private BoxCollider boxCollider;
+
+    
+
+
+    /* Set up all field references and event subscription.
+     */ 
+    private void Awake()
+    {
+        parentObject = gameObject.transform.parent.gameObject;
+
+        Enemy enemy = parentObject.GetComponent<Enemy>();
+        enemy.deathEvent += OnEnemyDied;
+
+        attackController = parentObject.GetComponent<AIAttackController>();
+        boxCollider = gameObject.GetComponent<BoxCollider>();
+    }
+
+
+    /* When the player is detected, enable the attack controller.
+     */
+    private void OnTriggerEnter(Collider other)
+    {
+        if (!other.gameObject.CompareTag("Player")) return;
+
+        Vector3 direction = other.gameObject.transform.position - parentObject.transform.position;
+
+        RaycastHit hit;
+
+        if (Physics.Raycast(parentObject.transform.position, direction, out hit))
+        {
+            if (hit.transform.gameObject.CompareTag("Player"))
+            {
+                Debug.Log("No obstacles between player and enemy. Fire!");
+                attackController.enabled = true;
+            }
+        }
+    }
+
+
+    /* When the player is no longer detected, disable attack controller.
+     */ 
+    private void OnTriggerExit(Collider other)
+    {
+        if (!other.gameObject.CompareTag("Player")) return;
+
+        attackController.enabled = false;
+    }
+
+
+    /* Called when the enemy dies. Stops attempting to detect the player.
+     */ 
+    private void OnEnemyDied(GameObject enemy)
+    {
+        boxCollider.enabled = false;
+    }
+}

--- a/Assets/Scripts/Entity/Enemy/DetectPlayer.cs.meta
+++ b/Assets/Scripts/Entity/Enemy/DetectPlayer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2bf13059866adf44e995ce57cf033022
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Entity/Enemy/Enemy.cs
+++ b/Assets/Scripts/Entity/Enemy/Enemy.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.AI;
 
 public class Enemy : Entity
 {
@@ -16,11 +17,17 @@ public class Enemy : Entity
     public delegate void HealthChanged();
     public event HealthChanged healthChangedEvent;
 
+    // Navmesh stuff
+    private NavMeshAgent agent;
+    private NavMeshObstacle navObstacle;
+
 
     /* Called before the game starts. Sets up all necessary info.
      */
     void Awake()
     {
+        agent = GetComponent<NavMeshAgent>();
+        navObstacle = GetComponent<NavMeshObstacle>();
     }
 
 
@@ -76,6 +83,15 @@ public class Enemy : Entity
 
         // Signal the death of this enemy
         deathEvent?.Invoke(gameObject);
-        OnDeath(); // Call Entity.OnDeath()
+
+        // Call Entity.OnDeath()
+        OnDeath();
+
+        if (agent != null)
+        {
+            agent.enabled = false;
+        }
+
+        navObstacle.enabled = true;
     }
 }


### PR DESCRIPTION
Certainly not the most clever player detection strategy, but I think it's better than what we have currently.

Right now, the enemies will just shoot blindly no matter what, as soon as they've spawned.

Instead, we should make them shoot the player only once they've detected him, and only if there are no obstacles blocking their line of sight.