### PR TITLE
Increase the cruz hitbox

### DIFF
--- a/Assets/Prefabs/Enemy/CruzEnemy.prefab
+++ b/Assets/Prefabs/Enemy/CruzEnemy.prefab
@@ -211,7 +211,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 1, y: 2, z: 1}
+  m_Size: {x: 1.8, y: 2, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!54 &688633171
 Rigidbody:
@@ -236,6 +236,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1016939505023120830}
     m_Modifications:
+    - target: {fileID: 100044, guid: 7b8cf766c639f374c8e9dade4e5c115a, type: 3}
+      propertyPath: m_Name
+      value: CruzModel
+      objectReference: {fileID: 0}
     - target: {fileID: 400044, guid: 7b8cf766c639f374c8e9dade4e5c115a, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -279,10 +283,6 @@ PrefabInstance:
     - target: {fileID: 400044, guid: 7b8cf766c639f374c8e9dade4e5c115a, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 100044, guid: 7b8cf766c639f374c8e9dade4e5c115a, type: 3}
-      propertyPath: m_Name
-      value: CruzModel
       objectReference: {fileID: 0}
     - target: {fileID: 9500000, guid: 7b8cf766c639f374c8e9dade4e5c115a, type: 3}
       propertyPath: m_Controller


### PR DESCRIPTION
The cruz actually had a hitbox as large as any other enemy. Yet
it did feel like it was harder to hit. I think it was an illusion caused
by it's arms. I extended the hit box to just before the length of the
arms. Extending the hitbox to the length of the arms, I think would make
the hitbox far too large.