### PR TITLE
Feature/improve heart drops fallrate

### DIFF
--- a/Assets/Scenes/SandboxScenes/JazySandbox.unity
+++ b/Assets/Scenes/SandboxScenes/JazySandbox.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.18028373, g: 0.22571397, b: 0.30692282, a: 1}
+  m_IndirectSpecularColor: {r: 0.18028381, g: 0.22571406, b: 0.30692294, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -9002,9 +9002,7 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents:
-    - {fileID: 1016939505879649365, guid: 960ce538aa7c32e4b8477465bf437679, type: 3}
-    - {fileID: 1016939505879649352, guid: 960ce538aa7c32e4b8477465bf437679, type: 3}
+    m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 960ce538aa7c32e4b8477465bf437679, type: 3}
 --- !u!1 &1224860694256207739
 GameObject:

--- a/Assets/Scripts/Entity/Enemy/EnemyDrop.cs
+++ b/Assets/Scripts/Entity/Enemy/EnemyDrop.cs
@@ -13,8 +13,8 @@ public class EnemyDrop : MonoBehaviour
     public List<GameObject> heartPrefabs = new List<GameObject>();
     public List<float> weights = new List<float>();
     public float healthDropProbability;
-    public int xzRange = 600;
-    public int yForce = 800;
+    public int xzSpawnVelocityMax = 5;
+    public int ySpawnVelocity = 0;
     public float spawnHeight = 2.5f;
 
     private List<Drop> drops = new List<Drop>();
@@ -67,13 +67,13 @@ public class EnemyDrop : MonoBehaviour
         var chance = Random.value;
         if (chance <= healthDropProbability)
         {
-            var randX = Random.Range(-xzRange, xzRange);
-            var randZ = Random.Range(-xzRange, xzRange);
+            var randX = Random.Range(-xzSpawnVelocityMax, xzSpawnVelocityMax);
+            var randZ = Random.Range(-xzSpawnVelocityMax, xzSpawnVelocityMax);
             var heart = Instantiate(heartType, transform.position + new Vector3(0, spawnHeight, 0), heartType.transform.rotation);
 
             var heartRb = heart.GetComponent<Rigidbody>();
 
-            heartRb.AddForce(new Vector3(randX, yForce, randZ));
+            heartRb.AddForce(new Vector3(randX, ySpawnVelocity, randZ), ForceMode.VelocityChange);
         }
     }
 }


### PR DESCRIPTION
What I did was change their spawn "force" to a spawn velocity instead.
This way the speed at which they spawn is independent of their mass. As
for the fall rate, mass does not affect the downward acceleration, but I
can control the initial upward velocity. So I set it to 0 so that the
heart begins falling as soon as it spawns. Hopefully, this fall rate
is fast enough to be desirable.