### PR TITLE
Enemy health event hotfix

### DIFF
--- a/Assets/Scripts/Entity/Enemy/Enemy.cs
+++ b/Assets/Scripts/Entity/Enemy/Enemy.cs
@@ -50,13 +50,11 @@ public class Enemy : Entity
         Health += amount;
         if (Health < 0) Health = 0;
 
-        if(Health == 0)
+        healthChangedEvent?.Invoke();
+
+        if (Health == 0)
         {
             OnEnemyDied();
-        }
-        else
-        {
-            healthChangedEvent?.Invoke();
         }
     }
 


### PR DESCRIPTION
Thanks @Jazy5552 for catching this one

Courtesy of my spaghetti logic here:

![image](https://user-images.githubusercontent.com/19352442/55257040-1c1e4180-5235-11e9-9aa2-8c88cd4d969a.png)

If an enemy had less health than the player's damage, they'd get killed without the health event ever firing. So this would lead to a very nasty bug where the player detection would not disable.