### PR TITLE
Fix particle spawning after restart

### DIFF
--- a/Assets/Scripts/Weapons/Projectile/Projectile.cs
+++ b/Assets/Scripts/Weapons/Projectile/Projectile.cs
@@ -42,7 +42,7 @@ public class Projectile : MonoBehaviour
     void hit()
     {
         // Notify any event listeners
-        OnHit(transform.position);
+        OnHit?.Invoke(transform.position);
         // Destroy the object
         Destroy(gameObject);
     }

--- a/Assets/Scripts/Weapons/Projectile/Projectile.cs
+++ b/Assets/Scripts/Weapons/Projectile/Projectile.cs
@@ -4,12 +4,14 @@ using UnityEngine;
 
 public class Projectile : MonoBehaviour
 {
+    public delegate void OnHitHandler(Vector3 position);
+    public event OnHitHandler OnHit;
     public Vector3 velocity;
     public int damage = 1;
 
 
     /* Projectiles self-destruct when colliding with walls.
-     */ 
+     */
     void OnTriggerEnter(Collider other)
     {
         GameObject otherObject = other.gameObject;
@@ -17,7 +19,7 @@ public class Projectile : MonoBehaviour
         // Disappear when hitting walls
         if (otherObject.CompareTag("Wall"))
         {
-            Destroy(gameObject);
+            hit();
         }
         // Damage enemy
         else if( (otherObject.CompareTag("Enemy") || otherObject.CompareTag("Boss")) && 
@@ -30,23 +32,35 @@ public class Projectile : MonoBehaviour
         {
             // Damage player
             otherObject.GetComponent<Player>().ChangeHealthBy(-damage);
-            Destroy(gameObject);
+            hit();
         }
+    }
+
+    /**
+        Method that is called when the projectile hits something and will be destroyed
+     */
+    void hit()
+    {
+        // Notify any event listeners
+        OnHit(transform.position);
+        // Destroy the object
+        Destroy(gameObject);
     }
 
 
     void DamageEnemy(GameObject enemy)
     {
         Enemy enemyController = enemy.GetComponent<Enemy>();
+        // Only damage and destroy the projectile if the enemy is alive
         if (enemyController.IsDead()) return;
 
         enemyController.ChangeHealthBy(-damage);
-        Destroy(gameObject);
+        hit();
     }
 
 
     /* Once spawned and given a speed, a projectile will travel at its velocity
-     */ 
+     */
     void Update()
     {
         transform.position += velocity * Time.deltaTime;

--- a/Assets/Scripts/Weapons/Projectile/ProjectileHitEffect.cs
+++ b/Assets/Scripts/Weapons/Projectile/ProjectileHitEffect.cs
@@ -12,6 +12,7 @@ public class ProjectileHitEffect : MonoBehaviour
     void Awake()
     {
         pro = GetComponent<Projectile>();
+        pro.OnHit += projectileOnHit;
     }
 
     void Emit(Vector3 position, Vector3 direction)
@@ -20,10 +21,9 @@ public class ProjectileHitEffect : MonoBehaviour
         Instantiate(hitParticleSystem, position + direction, Quaternion.LookRotation(direction));
     }
 
-    void OnDestroy()
+    void projectileOnHit(Vector3 position)
     {
         Vector3 direction = Vector3.Normalize(-pro.velocity);
-        Vector3 position = transform.position;
         Emit(position, direction);
     }
 }


### PR DESCRIPTION
Created a new system for when to spawn the particle effects by
using an event. This is fix an error where, upon restarting with
a projectile on screen, it would  destroy it and attempt to spawn
the particle effects.