### PR TITLE
Rapid heart blinking bug fix

### DIFF
--- a/Assets/Scripts/Entity/Player/Possession.cs
+++ b/Assets/Scripts/Entity/Player/Possession.cs
@@ -100,6 +100,9 @@ public class Possession : MonoBehaviour
             player.Health = enemy.GetComponent<Enemy>().MaxHealth;
         }
         
+        //update HUD
+        player.ChangeMaxHealthBy(0);
+        
         //Unload Excess Hearts
         if(heartdiff > 0)
         {

--- a/Assets/Scripts/Entity/Player/Possession.cs
+++ b/Assets/Scripts/Entity/Player/Possession.cs
@@ -100,9 +100,6 @@ public class Possession : MonoBehaviour
             player.Health = enemy.GetComponent<Enemy>().MaxHealth;
         }
         
-        //update HUD
-        player.ChangeMaxHealthBy(0);
-        
         //Unload Excess Hearts
         if(heartdiff > 0)
         {

--- a/Assets/Scripts/Environmental/UI/HeartSystem.cs
+++ b/Assets/Scripts/Environmental/UI/HeartSystem.cs
@@ -41,6 +41,7 @@ public class HeartSystem : MonoBehaviour
         maxAttainableHearts = heartImages.Length;
         AssociateWith(GameObject.FindWithTag("Player").GetComponent<Player>());
 
+        playerAtCriticalHealth = false;
         defaultHeartScale = heartImages[0].transform.localScale;
     }
 
@@ -68,8 +69,11 @@ public class HeartSystem : MonoBehaviour
         // Critical health
         if (player.Health <= 2 && player.Health != 0 && player.Health < player.MaxHealth)
         {
-            playerAtCriticalHealth = true;
-            StartCoroutine(BlinkCriticalHealth());
+            if(!playerAtCriticalHealth)
+            {
+                playerAtCriticalHealth = true;
+                StartCoroutine(BlinkCriticalHealth());
+            }
         }
         else
         {


### PR DESCRIPTION
This one was a pretty sneaky bug/edge case that I noticed a couple times.

If you were at critical health and your last heart container was blinking, and you possessed an enemy, the container would start blinking even more rapidly.

The reason this happened was because of the following logical oversight:

![image](https://user-images.githubusercontent.com/19352442/55588847-d82bb080-56fc-11e9-9159-8f2912da3d33.png)

This meant that if you were already on critical health, another coroutine would start up anyway, and you'd have double flashing.