### PR TITLE
Hotfix: bug with automatic pause menu navigation

### DIFF
--- a/Assets/Prefabs/GameManager.prefab
+++ b/Assets/Prefabs/GameManager.prefab
@@ -1022,8 +1022,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
-    m_Mode: 3
-    m_SelectOnUp: {fileID: 0}
+    m_Mode: 4
+    m_SelectOnUp: {fileID: 506861223}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
     m_SelectOnRight: {fileID: 0}
@@ -1743,6 +1743,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c946cb4df94b6f245b6e781186d022cb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  gameIsPaused: 0
   player: {fileID: 0}
   pauseMenuUI: {fileID: 4474975296555284949}
   eventSystem: {fileID: 2782640155977967466}


### PR DESCRIPTION
Because the pause menu was set up with automatic navigation on all the buttons, this meant Unity would map the UI elements in terms of their vertical arrangement:

![image](https://user-images.githubusercontent.com/19352442/55752930-27345700-5a17-11e9-8a27-240a4b49d69a.png)

Which effectively meant the Quit button got mapped to the BossHealthBar when down was pressed:

![image](https://user-images.githubusercontent.com/19352442/55752829-e89e9c80-5a16-11e9-920b-9314929fa2a2.png)
